### PR TITLE
Fix alignment of chat messages.

### DIFF
--- a/ImgToMC.py
+++ b/ImgToMC.py
@@ -37,7 +37,7 @@ def onfimHandler(link):
 
 def generateTellraw(hexList):
     out = []
-    out.append('tellraw @a [""')
+    out.append('tellraw @a [" "')
     for x in hexList:
         out.append(",")
         out.append(r'{"text":"#","color":"#' + x + r'"}')


### PR DESCRIPTION
Minecraft adds a space character at the start of every newline, so adding a space to the first line causes them to align.